### PR TITLE
Arrival forecast search service

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,2 +1,9 @@
+require 'sptrans/arrival_forecast_search'
+
 class HomeController < ApplicationController
+  def arrival_forecast
+    response = SPTrans::ArrivalForecastSearch.new.call(params[:stop_code])
+
+    render json: response
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   root to: 'home#index'
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  get 'arrival_forecat/:stop_code', to: 'home#arrival_forecast', as: :arrival_forecast
 end

--- a/lib/sptrans/api_connection.rb
+++ b/lib/sptrans/api_connection.rb
@@ -1,12 +1,11 @@
-require 'json'
-require 'httpclient'
+module SPTrans
+  API_URL = "http://api.olhovivo.sptrans.com.br/v0"
 
-module APIConnection
-  def self.connect
+  def self.connect(client)
     token = "5e20a6e514afa82121420017cbaf867bc2fca8b13c30f76b3c179f42f10ae486"
+
     begin
-      @client = HTTPClient.new
-      @client.post "http://api.olhovivo.sptrans.com.br/v0/login/autenticar?token=#{token}",{}
+      client.post("#{API_URL}/login/autenticar?token=#{token}", {})
     rescue Exception => e
       puts "Problema na conexão."
       puts e.message

--- a/lib/sptrans/arrival_forecast_search.rb
+++ b/lib/sptrans/arrival_forecast_search.rb
@@ -1,0 +1,19 @@
+require 'sptrans/api_connection'
+
+module SPTrans
+  class ArrivalForecastSearch
+    def initialize
+      @client = HTTPClient.new
+      SPTrans.connect(@client)
+    end
+
+    def call(stop_code)
+      response = @client.get(
+        "#{API_URL}/Previsao/Parada",
+        { codigoParada: stop_code }
+      )
+
+      JSON.parse(response.body)
+    end
+  end
+end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -6,5 +6,11 @@ RSpec.describe HomeController, type: :controller do
       get :index
       expect(response.status).to eq(200)
     end
-  end  
+  end
+
+  describe 'GET #arrival_forecast' do
+    subject { get :arrival_forecast, params: { stop_code: 123 } }
+
+    it { is_expected.to have_http_status :ok }
+  end
 end

--- a/spec/lib/api_connection_spec.rb
+++ b/spec/lib/api_connection_spec.rb
@@ -1,9 +1,0 @@
-require 'spec_helper'
-require './lib/api_connection'
-
-describe APIConnection do
-  subject { APIConnection::connect.code  }
-  it "works and response true" do
-    is_expected.to eql 200
-  end
-end

--- a/spec/lib/sptrans/api_connection_spec.rb
+++ b/spec/lib/sptrans/api_connection_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+require './lib/sptrans/api_connection'
+
+describe SPTrans do
+  describe ".connect" do
+    subject { SPTrans.connect(HTTPClient.new).status_code }
+
+    it { is_expected.to eq 200 }
+  end
+end

--- a/spec/lib/sptrans/arrival_forecast_search_spec.rb
+++ b/spec/lib/sptrans/arrival_forecast_search_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+require 'sptrans/arrival_forecast_search'
+
+describe SPTrans::ArrivalForecastSearch do
+  describe '#call' do
+    it "returns a hash with data" do
+      response = described_class.new.call("4200953")
+
+      expect(response.class).to eq Hash
+      expect(response).to_not be_empty
+    end
+  end
+end


### PR DESCRIPTION
Este PR contém:

  - Criação do módulo `SPTrans` para todos os arquivos do service;
  - Adptação do metodo `connection` para receber uma instância HTTPClient como argumento;
  - Implementação de uma classe que "Retorna uma lista com a previsão de chegada dos veículos de cada uma das linhas que atendem ao ponto de parada informado." (de acordo com a documentação);
 - Implementação da action que exibe estes dados como json na tela (apenas provisório).

Antes de mais nada, este PR contém uma sugestão de organização para as classes que vão realizar as buscas na API da SPTrans, que pode ser aprovada ou não.