### PR TITLE
Add new searchByTerm method on arrival forecast search

### DIFF
--- a/lib/sptrans/arrival_forecast_search.rb
+++ b/lib/sptrans/arrival_forecast_search.rb
@@ -40,5 +40,15 @@ module SPTrans
         puts e.backtrace.inspect
       end
     end
+
+    def searchByTerm(line_code)
+      begin
+        response = @client.get "#{ENV['API_URL']}/Linha/Buscar?termosBusca=#{line_code}", {}
+        return JSON.parse(response.body)
+      rescue Exception => e
+        puts e.message
+        puts e.backtrace.inspect
+      end
+    end
   end
 end

--- a/spec/lib/sptrans/arrival_forecast_search_spec.rb
+++ b/spec/lib/sptrans/arrival_forecast_search_spec.rb
@@ -31,4 +31,13 @@ describe SPTrans::ArrivalForecastSearch do
       expect(response).to_not be_empty
     end
   end
+
+  describe '#searchByTerm' do 
+    it 'returns a hash with data' do
+      response = @api.searchByTerm("8000")
+
+      expect(response.class). to eq Array
+      expect(response).to_not be_empty
+    end
+  end
 end


### PR DESCRIPTION
Creation of a new method on SPTrans::ArrivalForecastSearch to search lines by term.